### PR TITLE
ensure-buffer: allow buffer size to be changed

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -185,6 +185,20 @@ See ENTRY-TO-STREAM
 See ENTRY-TO-VECTOR
 See ARCHIVE-FILE-REQUIRED"))
 
+;; toolkit.lisp
+(docs:define-docs
+  (variable *default-buffer-size*
+    "Default buffer size when working on compressed data.
+
+For example this can be bound around calls to DECODE-ENTRY to give a
+more accurate size for the temporary buffer being allocated to decode
+a particular file.
+
+See DECODE-ENTRY
+See ENCODE-FILE
+See MAKE-DECRYPTION-STATE
+See MAKE-DECOMPRESSION-STATE"))
+
 ;; encode.lisp
 (docs:define-docs
   (variable *default-version-made*

--- a/package.lisp
+++ b/package.lisp
@@ -121,7 +121,8 @@
    #:encryption-method-name
    #:encryption-method-id)
   ;; toolkit.lisp
-  (:export)
+  (:export
+   #:*default-buffer-size*)
   ;; zippy.lisp
   (:export
    #:zip-file

--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -17,6 +17,8 @@
   #+darwin :darwin
   #+(and unix (not darwin)) :unix)
 
+(defvar *default-buffer-size* 4096)
+
 (defun default-attributes-for (system)
   (case system
     ((:darwin :unix) #o644)
@@ -26,7 +28,7 @@
   (etypecase buffer
     (vector buffer)
     (integer (make-array buffer :element-type '(unsigned-byte 8)))
-    (null (make-array 4096 :element-type '(unsigned-byte 8)))))
+    (null (make-array *default-buffer-size* :element-type '(unsigned-byte 8)))))
 
 (defun ensure-password (password)
   (etypecase password


### PR DESCRIPTION
I am in a case where I am partially decoding an entry to extract metadata, so I call `decode-entry` directly with a callback that calls `(throw ...)` once I am done. The default size of 4096 is however too large for my use case, and I thought that maybe this could be a parameter instead.