### PR TITLE
decode-extra-fields: fix off-by-one error

### DIFF
--- a/decode.lisp
+++ b/decode.lisp
@@ -15,7 +15,7 @@
                (when dec
                  (push (funcall (first dec) vector index) fields))
                (if (< index (length vector))
-                   (incf index (nibbles:ub16ref/le vector index))
+                   (incf index (+ 2 (nibbles:ub16ref/le vector index)))
                    (return))))
     (nreverse fields)))
 


### PR DESCRIPTION
Hi again, when using the library to decode extra fields I noticed a problem I think.

For example with tests/many.zip:

    $ zipdetails tests/many.zip |grep "Extra ID"|tail -n 2
    3F1C Extra ID #0001        5455 'UT: Extended Timestamp'
    3F25 Extra ID #0002        7875 'ux: Unix Extra Type 3'

If I change the decode.lisp as follows:

    -               (when dec
    -                 (push (funcall (first dec) vector index) fields))
    +               (if dec
    +                   (push (funcall (first dec) vector index) fields)
    +                   (warn "Unknown sig #x~x" sig))

With the following test script:

    (defun test-extra-fields (file)
      (zippy:with-zip-file (zip file)
        (loop for e across (zippy:entries zip) do
          (when (plusp (zippy:uncompressed-size e))
            (alexandria:when-let (fields (zippy:extra-fields e))
              (print fields))))))

Then I obtain the following warnings:

    WARNING: Unknown sig #x5455
    WARNING: Unknown sig #x5F0B

Notice that the first field identifier is the same as the zipdetails output (5455), but the second one doesn't match (7875 vs. 5F0B). Looking at the raw bytes, near the end of the file we can see the following (using hd):

    39 38 55 54 05 00 03 ef 06 0b 5f 75 78 0b 00 01
          ^^^^^ %%%%% -------- !!!!! ^^^^^
          ID    SIZE           WRONG CORRECT
                -2    +0       +3    +5

The size of the first extra field is 5, but zippy takes for origin the current position of the size, and not the position after the size field (the spec says that the header ID takes 2 bytes and the data size takes 2 bytes, so I think it is incorrect to account for the size field as part of the data).

This is due partly because in structures.lisp all extra fields start with a size field, probably because we want to have a size accessor when *encoding* the value back. But then decode-extra-fields forgets to advance the index by the appropriate amount.